### PR TITLE
Stacking on top of crates

### DIFF
--- a/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
+++ b/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
@@ -43,6 +43,7 @@ public class ThirdPersonUserControl : MonoBehaviour
     private Vector3 pushedObjectTarget;     // where are we moving the crate TO 
     private Vector3 playerMoveOrig;         // where are we moving the player FROM
     private Vector3 pushedObjectOrig;       // where are we moving the crate FROM
+    private BoxStacking boxstack;
 
     bool pushForward;                       // players current status is pushing a crate forward
     bool pullBackwards;                     // players current status is pulling a crate towards themselves
@@ -235,6 +236,7 @@ public class ThirdPersonUserControl : MonoBehaviour
         {
             movingAnimationCount += Time.fixedDeltaTime;
             // Right now, this is just snapping the transform to the next square, so let's change that a bit!
+            Vector3 moveamount = p_Obj.transform.position;
             if (pushForward)
             {
                 // move crate first, then player
@@ -247,6 +249,8 @@ public class ThirdPersonUserControl : MonoBehaviour
                 p_Obj.transform.position = Vector3.Lerp(playerMoveOrig, playerMoveTarget, movingAnimationCount / completeMovingTime); //.Translate(ForceDirection, Space.World);
                 m_Character.grabbedBox.transform.position = Vector3.Lerp(pushedObjectOrig, pushedObjectTarget, movingAnimationCount / completeMovingTime); //.Translate(ForceDirection, Space.World);
             }
+            moveamount = p_Obj.transform.position - moveamount;
+            m_Character.grabbedBox.GetComponent<BoxStacking>().DoMove(moveamount);
             if (movingAnimationCount >= completeMovingTime)
             {
                 // we're done pushing!

--- a/Assets/Prefabs/Cubecrate.prefab
+++ b/Assets/Prefabs/Cubecrate.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 190203050819444076}
   - component: {fileID: 190203050819444079}
   - component: {fileID: 190203050819444077}
+  - component: {fileID: -487067203183454041}
   m_Layer: 8
   m_Name: Cubecrate
   m_TagString: Untagged
@@ -90,7 +91,7 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1036625590374036332}
   serializedVersion: 2
-  m_Mass: 1000
+  m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 1
@@ -125,5 +126,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxAngle: 50
   maxGrabDistance: 2.5
-  maxVerticalGrabDistance: 1.5
+  maxVerticalGrabDistance: 0.5
   pushThreshold: 0.2
+--- !u!114 &-487067203183454041
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036625590374036332}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ac5769e49929be4094c7c0b14440711, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/BoxPush.cs
+++ b/Assets/Scripts/BoxPush.cs
@@ -76,8 +76,7 @@ public class BoxPush : MonoBehaviour
         var angle = Vector3.Angle(cubeDir, player.forward);
 
         //if the player is next to the box, on the same plane (Within reason, this might need to be samller)
-        Debug.Log("Diff of y pos: " + Mathf.Abs(transform.position.y - (player.position.y + playHalfHeight)));
-        sameLevel = (Mathf.Abs(transform.position.y - (player.position.y + playHalfHeight)) < maxVerticalGrabDistance);   // TODO: Make this variable so we can adjust
+        sameLevel = (Mathf.Abs(transform.position.y - (player.position.y + playHalfHeight)) < maxVerticalGrabDistance);
         float PlayerToBoxLevelDistance = Mathf.Abs(transform.position.y - player.position.y);
         // If you want to see info about a box, just tag it TestBox
         if (gameObject.tag == "TestBox")
@@ -86,14 +85,6 @@ public class BoxPush : MonoBehaviour
             Debug.Log("Angel: " + angle);
             Debug.Log("CubeMagnitude: " + cubeDir.magnitude);
         }
-        /*
-        First, check that we're within some distance and we're at the same level
-        - if we are display the grab prompt
-        - if they've been holding down push for long enough near the box, let the player grab it
-        - if the player grabs the box, make the character move to where they should be standing
-        while thy are going to push the box
-        - Once player is grabbing the crate, we snap into quantized movement
-        */
 
         // Is the player currently in a state where they can push the box?
         canPushCrate = (cubeDir.magnitude < maxGrabDistance && sameLevel && angle < maxAngle); // TODO: Make this public and tweak to find good-good
@@ -102,10 +93,9 @@ public class BoxPush : MonoBehaviour
         // and just grab the flag from there
         playerHoldingUse = playerControls.HoldingUseButton;
 
-
         if (canPushCrate)
         {
-            // TODO: Display "Push" here
+            // TODO: Display "Push" here?
             // check if the player is holding down the E key
             // or they are holding down the proper button on
             // controller

--- a/Assets/Scripts/BoxPush.cs
+++ b/Assets/Scripts/BoxPush.cs
@@ -19,6 +19,7 @@ public class BoxPush : MonoBehaviour
 
     public float maxGrabDistance = 2.0f;
     public float maxVerticalGrabDistance = 0.8f;
+    private float playHalfHeight;
 
     private bool snapOnce;
 
@@ -44,6 +45,7 @@ public class BoxPush : MonoBehaviour
         //player = playerObject.transform;
         playerObject = GameObject.FindWithTag("Player");
         player = playerObject.transform;
+        playHalfHeight = 0.8f;
 
         playerRidgidBody = playerObject.GetComponent<Rigidbody>();
         playerControls = playerObject.GetComponent<ThirdPersonUserControl>();
@@ -74,7 +76,8 @@ public class BoxPush : MonoBehaviour
         var angle = Vector3.Angle(cubeDir, player.forward);
 
         //if the player is next to the box, on the same plane (Within reason, this might need to be samller)
-        sameLevel = (Mathf.Abs(transform.position.y - player.position.y) < maxVerticalGrabDistance);   // TODO: Make this variable so we can adjust
+        Debug.Log("Diff of y pos: " + Mathf.Abs(transform.position.y - (player.position.y + playHalfHeight)));
+        sameLevel = (Mathf.Abs(transform.position.y - (player.position.y + playHalfHeight)) < maxVerticalGrabDistance);   // TODO: Make this variable so we can adjust
         float PlayerToBoxLevelDistance = Mathf.Abs(transform.position.y - player.position.y);
         // If you want to see info about a box, just tag it TestBox
         if (gameObject.tag == "TestBox")
@@ -150,7 +153,7 @@ public class BoxPush : MonoBehaviour
             secondsOfPushing = 0.0f;
             playerIsPushing = false;
             playerGrabbing = false;
-            boxRigidbody.constraints = RigidbodyConstraints.FreezeRotation;
+            boxRigidbody.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionX | RigidbodyConstraints.FreezePositionZ;
         }
 
         if (playerIsPushing)

--- a/Assets/Scripts/BoxStacking.cs
+++ b/Assets/Scripts/BoxStacking.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BoxStacking : MonoBehaviour
+{
+    private GameObject origparent;
+    private Transform childobject;
+    // Start is called before the first frame update
+    private void OnCollisionEnter(Collision collision)
+    {
+
+        if (collision.transform.position.y > transform.position.y)
+        {
+
+            childobject = collision.gameObject.transform;
+            Debug.Log("I'm " + this.gameObject + " and my child is " + collision.gameObject);
+            // Debug.Log("Collision is here!");
+            //origparent = collision.gameObject.transform.parent.gameObject;
+            //collision.gameObject.transform.parent = this.transform;
+        }
+    }
+
+    private void OnCollisionExit(Collision collision)
+    {
+        if (collision.transform.position.y > transform.position.y)
+        {
+            //collision.gameObject.transform.parent = origparent.transform;
+            childobject = null;
+        }
+    }
+
+    public void DoMove(Vector3 move)
+    {
+        Debug.Log("I'm in DOMOVE");
+        if (childobject)
+        {
+            Debug.Log("And I have a child!");
+            childobject.position += move;
+        }
+    }
+}

--- a/Assets/Scripts/BoxStacking.cs
+++ b/Assets/Scripts/BoxStacking.cs
@@ -1,12 +1,17 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityScript.Steps;
 
 public class BoxStacking : MonoBehaviour
 {
     private GameObject origparent;
-    private Transform childobject;
+    private List<GameObject> childobjects;
     // Start is called before the first frame update
+    private void Start()
+    {
+        childobjects = new List<GameObject> { };
+    }
     private void OnCollisionEnter(Collision collision)
     {
         if (collision.gameObject.tag == "Player")
@@ -15,8 +20,7 @@ public class BoxStacking : MonoBehaviour
         }
         if (collision.transform.position.y > transform.position.y)
         {
-
-            childobject = collision.gameObject.transform;
+            childobjects.Add(collision.gameObject);
         }
     }
 
@@ -26,18 +30,15 @@ public class BoxStacking : MonoBehaviour
         {
             return; // Ignore the player! We don't ever want to unstack them from crates!
         }
-
-        if (collision.transform.position.y > transform.position.y)
-        {
-            childobject = null;
-        }
+        childobjects.Remove(collision.gameObject);
+        
     }
 
     public void DoMove(Vector3 move)
     {
-        if (childobject)
+        foreach (GameObject childobject in childobjects)
         {
-            childobject.position += move;
+            childobject.transform.position += move;
         }
     }
 }

--- a/Assets/Scripts/BoxStacking.cs
+++ b/Assets/Scripts/BoxStacking.cs
@@ -9,33 +9,34 @@ public class BoxStacking : MonoBehaviour
     // Start is called before the first frame update
     private void OnCollisionEnter(Collision collision)
     {
-
+        if (collision.gameObject.tag == "Player")
+        {
+            return; // Ignore the player! We don't ever want to stack them on the crate!
+        }
         if (collision.transform.position.y > transform.position.y)
         {
 
             childobject = collision.gameObject.transform;
-            Debug.Log("I'm " + this.gameObject + " and my child is " + collision.gameObject);
-            // Debug.Log("Collision is here!");
-            //origparent = collision.gameObject.transform.parent.gameObject;
-            //collision.gameObject.transform.parent = this.transform;
         }
     }
 
     private void OnCollisionExit(Collision collision)
     {
+        if (collision.gameObject.tag == "Player")
+        {
+            return; // Ignore the player! We don't ever want to unstack them from crates!
+        }
+
         if (collision.transform.position.y > transform.position.y)
         {
-            //collision.gameObject.transform.parent = origparent.transform;
             childobject = null;
         }
     }
 
     public void DoMove(Vector3 move)
     {
-        Debug.Log("I'm in DOMOVE");
         if (childobject)
         {
-            Debug.Log("And I have a child!");
             childobject.position += move;
         }
     }

--- a/Assets/Scripts/BoxStacking.cs.meta
+++ b/Assets/Scripts/BoxStacking.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ac5769e49929be4094c7c0b14440711
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Objects can be stacked on top of crate and pushed around now, try other crate or robot in first level, right now only one object on a crate at a time is supported, but since only one crate can fit on top of another one, it should be ok? We might have to deal with some other cases as I see how this is going to be used in different puzzles
- Fixed bug where player would grab  box underneath themselves (Players transform was at their feet, so adding half the player height to compensate for this seemed to do the trick)
- Please test in levels and let me know any bugs that arise!