### PR TITLE
Itemui

### DIFF
--- a/Assets/Characters/ThirdPersonCharacter/Prefabs/PlayerWithUI.prefab
+++ b/Assets/Characters/ThirdPersonCharacter/Prefabs/PlayerWithUI.prefab
@@ -1,0 +1,355 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1295999834
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1295999835}
+  m_Layer: 0
+  m_Name: TapeUIContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1295999835
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1295999834}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 344.33, y: -80.36592, z: 1.3000067}
+  m_LocalScale: {x: 556.16315, y: 556.16315, z: 556.16315}
+  m_Children:
+  - {fileID: 1854743107}
+  - {fileID: 1308615154378584341}
+  m_Father: {fileID: 7672142046229033899}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1854743106
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1854743107}
+  - component: {fileID: 1854743109}
+  - component: {fileID: 1854743108}
+  m_Layer: 5
+  m_Name: ItemText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1854743107
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854743106}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0016966}
+  m_LocalScale: {x: 0.0013051206, y: 0.0013051206, z: 0.0013051206}
+  m_Children: []
+  m_Father: {fileID: 1295999835}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.58579254, y: 0.10638}
+  m_SizeDelta: {x: 172.61536, y: 42.443542}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1854743109
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854743106}
+  m_CullTransparentMesh: 0
+--- !u!114 &1854743108
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854743106}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.39215687}
+  m_RaycastTarget: 0
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 3c728f163d9ac214b9a9af1c18ef6b1c, type: 3}
+    m_FontSize: 18
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Default
+--- !u!1001 &1559261357969078467
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 149790, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_Name
+      value: ThirdPersonController
+      objectReference: {fileID: 0}
+    - target: {fileID: 149790, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_TagString
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.5009894
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.460925
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.70710576
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071079
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 408730, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11469404, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_AnimSpeedMultiplier
+      value: 1.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 11469404, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_GroundCheckDistance
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 13615390, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_Center.y
+      value: 0.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 13783410, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 3bde03a53c93cc24cac3c8871bdeaf68, type: 2}
+    - target: {fileID: 2654804492679217102, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5299397951810176211, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: firstbot
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5299397951810176211, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: roboSpeed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5299397951810176211, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: completeMovingTime
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6963762203352499300, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8884501547963696652, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: m_TargetCamera
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8884501547963696656, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8884501547963696656, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9213088833377244886, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 9213088833377244887, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9213088833377244907, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: m_Name
+      value: ItemUIMain
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7737647c22c1fc64a88d5cd030c352ce, type: 3}
+--- !u!224 &7672142046229033899 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 9213088834129791848, guid: 7737647c22c1fc64a88d5cd030c352ce,
+    type: 3}
+  m_PrefabInstance: {fileID: 1559261357969078467}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1559261358859540222
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1295999835}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.58519
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.19278
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.50000006
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.50000006
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.50000006
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.49999997
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90.00001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90.00001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.39153624
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.9153612
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3.9153612
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: eff3ab2b695a2cd479d9bccd8496688d, type: 2}
+    - target: {fileID: 919132149155446097, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_Name
+      value: ItemModel
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee5f5fee75849484faf38995ff5a57ff, type: 3}
+--- !u!4 &1308615154378584341 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+    type: 3}
+  m_PrefabInstance: {fileID: 1559261358859540222}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Characters/ThirdPersonCharacter/Prefabs/PlayerWithUI.prefab.meta
+++ b/Assets/Characters/ThirdPersonCharacter/Prefabs/PlayerWithUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0b7789ffffa8e7c49958de5565dc3172
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Characters/ThirdPersonCharacter/Prefabs/ThirdPersonController.prefab
+++ b/Assets/Characters/ThirdPersonCharacter/Prefabs/ThirdPersonController.prefab
@@ -1497,6 +1497,7 @@ Transform:
   - {fileID: 495908}
   - {fileID: 448028}
   - {fileID: 8884501547963696656}
+  - {fileID: 9213088833377244887}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1598,6 +1599,7 @@ MonoBehaviour:
   playerMoveInWorld: {x: 0, y: 0, z: 0}
   HoldingUseButton: 0
   PushPullThreshold: 1
+  RobotCaptureMaxDistance: 3
   completeMovingTime: 2
   isInMovingAnimation: 0
 --- !u!82 &416733105112643345
@@ -3117,4 +3119,129 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8795561723581898670, guid: 0a8b4e27ef2b7ef489bd99fd81405739,
     type: 3}
   m_PrefabInstance: {fileID: 97966333879638462}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3652521027633141043
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 408730}
+    m_Modifications:
+    - target: {fileID: 5578600936825570264, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_Name
+      value: ItemCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1b48f867f6ab26844b876fa4912a77e6, type: 3}
+--- !u!224 &9213088833377244887 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5578600936825570276, guid: 1b48f867f6ab26844b876fa4912a77e6,
+    type: 3}
+  m_PrefabInstance: {fileID: 3652521027633141043}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonCharacter.cs
+++ b/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonCharacter.cs
@@ -30,6 +30,7 @@ public class ThirdPersonCharacter : MonoBehaviour
 
     private ItemUI itemUI;
     public bool HasKey;
+    public bool HasTape;
 
     public bool lockOnXAxis;
     public bool lockOnZAxis;
@@ -238,6 +239,14 @@ public class ThirdPersonCharacter : MonoBehaviour
         else
         {
             itemUI.NoItem();
+        }
+        if (HasTape)
+        {
+            itemUI.AcquireTape("Tape");
+        }
+        else
+        {
+            itemUI.NoTape();
         }
     }
 

--- a/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonCharacter.cs
+++ b/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonCharacter.cs
@@ -45,6 +45,7 @@ public class ThirdPersonCharacter : MonoBehaviour
     public float FootstepDelay = 0.2f;
     private float footstepcount;
 
+
     void Start()
     {
         m_Animator = GetComponent<Animator>();
@@ -62,7 +63,7 @@ public class ThirdPersonCharacter : MonoBehaviour
         audios = GetComponent<AudioSource>();
         footstepcount = 0;
 
-        // itemUI = GameObject.Find("ItemUI").GetComponent<ItemUI>();
+        itemUI = GameObject.Find("ItemUI").GetComponent<ItemUI>();
     }
 
 
@@ -228,17 +229,17 @@ public class ThirdPersonCharacter : MonoBehaviour
         }
     }
 
-    //private void OnGUI()
-    //{
-    //    if (HasKey)
-    //    {
-    //        itemUI.AcquireItem("Keycard");
-    //    }
-    //    else
-    //    {
-    //        itemUI.NoItem();
-    //    }
-    //}
+    private void OnGUI()
+    {
+        if (HasKey)
+        {
+            itemUI.AcquireItem("Keycard");
+        }
+        else
+        {
+            itemUI.NoItem();
+        }
+    }
 
     public void useKey()
     {

--- a/Assets/Prefabs/GettableObj.prefab
+++ b/Assets/Prefabs/GettableObj.prefab
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5482899346500175279
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5482899346500175272}
+  - component: {fileID: 5482899346500175268}
+  - component: {fileID: 5482899346500175275}
+  - component: {fileID: 5482899346500175274}
+  - component: {fileID: 5482899346500175273}
+  m_Layer: 0
+  m_Name: GettableObj
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5482899346500175272
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5482899346500175279}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.49, y: -0.267, z: -5.09}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5482899346500175268
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5482899346500175279}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5482899346500175275
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5482899346500175279}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 03219d3081d023a46ab474d6845c88cc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!136 &5482899346500175274
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5482899346500175279}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &5482899346500175273
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5482899346500175279}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 46defc2db4f23bd4d8d36436041907eb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Character: {fileID: 0}

--- a/Assets/Prefabs/GettableObj.prefab.meta
+++ b/Assets/Prefabs/GettableObj.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5854cf1c7d4fb884c9c5d42116a193f9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/GettableTape.prefab
+++ b/Assets/Prefabs/GettableTape.prefab
@@ -1,0 +1,109 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7829074935262120863
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7829074935262120856}
+  - component: {fileID: 7829074935262120852}
+  - component: {fileID: 7829074935262120859}
+  - component: {fileID: 7829074935262120858}
+  - component: {fileID: 2355767209437866165}
+  m_Layer: 0
+  m_Name: GettableTape
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7829074935262120856
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7829074935262120863}
+  m_LocalRotation: {x: -0, y: -0.70710576, z: 0, w: 0.7071079}
+  m_LocalPosition: {x: -9.659, y: 16, z: 5.952}
+  m_LocalScale: {x: 0.19999996, y: 0.2, z: 0.19999996}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7829074935262120852
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7829074935262120863}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7829074935262120859
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7829074935262120863}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 03219d3081d023a46ab474d6845c88cc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!136 &7829074935262120858
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7829074935262120863}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &2355767209437866165
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7829074935262120863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 827d5509d662e054ebf0d3245f1b4a07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/GettableTape.prefab.meta
+++ b/Assets/Prefabs/GettableTape.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 85f1c8669a7a3f84a948ea1a65ddb5c0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/ItemCanvas.prefab
+++ b/Assets/Prefabs/ItemCanvas.prefab
@@ -1,0 +1,382 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5578600935914692188
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5578600935914692187}
+  - component: {fileID: 5578600935914692186}
+  - component: {fileID: 5578600935914692185}
+  m_Layer: 5
+  m_Name: ItemUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5578600935914692187
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600935914692188}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5578600936363844131}
+  m_Father: {fileID: 5578600936825570276}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -283.6432, y: 149}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5578600935914692186
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600935914692188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e6fad859c7927847bd4a50f4ac9f41d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5578600935914692185
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600935914692188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36a0f8ce89271eb458ec6a10ea77e5e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemName: Default
+  iconRotationSpeed: 100
+  iconSlideSpeed: 1
+  waitAtCenterTime: 0.5
+--- !u!1 &5578600936363844132
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5578600936363844131}
+  m_Layer: 0
+  m_Name: ItemUIContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5578600936363844131
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600936363844132}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 283.6432, y: -80.36592, z: 1.3000067}
+  m_LocalScale: {x: 556.16315, y: 556.16315, z: 556.16315}
+  m_Children:
+  - {fileID: 5578600936841188479}
+  - {fileID: 5395754924165296001}
+  m_Father: {fileID: 5578600935914692187}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5578600936825570264
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5578600936825570276}
+  - component: {fileID: 5578600936825570277}
+  - component: {fileID: 5578600936825570278}
+  - component: {fileID: 5578600936825570279}
+  m_Layer: 5
+  m_Name: ItemCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5578600936825570276
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600936825570264}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 5578600935914692187}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &5578600936825570277
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600936825570264}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 1
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 0.6
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &5578600936825570278
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600936825570264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &5578600936825570279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600936825570264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &5578600936841188464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5578600936841188479}
+  - component: {fileID: 5578600936841188477}
+  - component: {fileID: 5578600936841188478}
+  m_Layer: 5
+  m_Name: ItemText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5578600936841188479
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600936841188464}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0016966}
+  m_LocalScale: {x: 0.0013051206, y: 0.0013051206, z: 0.0013051206}
+  m_Children: []
+  m_Father: {fileID: 5578600936363844131}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.58579254, y: 0.10638}
+  m_SizeDelta: {x: 172.61536, y: 42.443542}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5578600936841188477
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600936841188464}
+  m_CullTransparentMesh: 0
+--- !u!114 &5578600936841188478
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5578600936841188464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.39215687}
+  m_RaycastTarget: 0
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 3c728f163d9ac214b9a9af1c18ef6b1c, type: 3}
+    m_FontSize: 18
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Default
+--- !u!1001 &5578600935553402986
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5578600936363844131}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.58519
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.19278
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.50000006
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.50000006
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.50000006
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.49999997
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90.00001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90.00001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.39153624
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.9153612
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3.9153612
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: eff3ab2b695a2cd479d9bccd8496688d, type: 2}
+    - target: {fileID: 919132149155446097, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_Name
+      value: ItemModel
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ee5f5fee75849484faf38995ff5a57ff,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee5f5fee75849484faf38995ff5a57ff, type: 3}
+--- !u!4 &5395754924165296001 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ee5f5fee75849484faf38995ff5a57ff,
+    type: 3}
+  m_PrefabInstance: {fileID: 5578600935553402986}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/ItemCanvas.prefab.meta
+++ b/Assets/Prefabs/ItemCanvas.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1b48f867f6ab26844b876fa4912a77e6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GettableObject.cs
+++ b/Assets/Scripts/GettableObject.cs
@@ -4,11 +4,11 @@ using UnityEngine;
 
 public class GettableObject : MonoBehaviour
 {
-    public ThirdPersonCharacter m_Character; // A reference to the ThirdPersonCharacter
+    private ThirdPersonCharacter m_Character; // A reference to the ThirdPersonCharacter
     private void Start()
     {
         // get the third person character ( this should never be null due to require component )
-        // m_Character = GetComponent<ThirdPersonCharacter>();
+        m_Character = GameObject.FindGameObjectWithTag("Player").GetComponent<ThirdPersonCharacter>();
     }
 
     private void OnCollisionEnter(Collision collision)

--- a/Assets/Scripts/TapePickup.cs
+++ b/Assets/Scripts/TapePickup.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TapePickup:MonoBehaviour
+{
+    private ThirdPersonCharacter m_Character; // A reference to the ThirdPersonCharacter
+    private void Start()
+    {
+        // get the third person character ( this should never be null due to require component )
+        m_Character = GameObject.FindGameObjectWithTag("Player").GetComponent<ThirdPersonCharacter>();
+    }
+
+    private void OnCollisionEnter(Collision collision)
+    {
+        if (collision.gameObject.tag == "Player")
+        {
+            // TODO: player has now collected something!
+            m_Character.HasTape = true;
+            Destroy(gameObject);
+
+        }
+    }
+}

--- a/Assets/Scripts/TapePickup.cs.meta
+++ b/Assets/Scripts/TapePickup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 827d5509d662e054ebf0d3245f1b4a07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/ItemAcquireUI.cs
+++ b/Assets/Scripts/UI/ItemAcquireUI.cs
@@ -38,7 +38,6 @@ public class ItemAcquireUI : MonoBehaviour
         itemText.text = itemName.ToUpper();
 
         StartCoroutine("InitialRoutine");
-        Debug.Log("Started item acquire UI!");
     }
     void Update()
     {

--- a/Assets/Scripts/UI/ItemAcquireUI.cs
+++ b/Assets/Scripts/UI/ItemAcquireUI.cs
@@ -7,23 +7,35 @@ public class ItemAcquireUI : MonoBehaviour
 {
     // Name of the item. Set by ItemUI.
     public string itemName = "Default";
+    public string tapeName = "Tape";
+
     // How fast the icon rotates on its own axis.
     public float iconRotationSpeed = 100f;
+
     // How fast the icon slides from the center of the screen to its final resting position.
     public float iconSlideSpeed = 1f;
+
     // How long the icon stays at the center of the screen before moving.
     public float waitAtCenterTime = 0.5f;
+
     // Initially false until initial routine (moving into position, etc) is complete.
-    private bool doneInitialRoutine = false;
-    private Vector3 desiredPosition;
+    private bool doneInitialItemRoutine = false;
+    private bool doneInitialTapeRoutine = false;
+
+    private Vector3 desiredItemPosition;
     private GameObject itemUIContainer;
     private Text itemText;
     private GameObject itemModel;
 
-    void Awake()
-    {
-        enabled = false;
-    }
+    private Vector3 desiredTapePosition;
+    private GameObject tapeUIContainer;
+    private Text tapeText;
+    private GameObject tapeModel;
+
+    //void Awake()
+    //{
+    //    enabled = false;
+    //}
 
     void Start()
     {
@@ -32,28 +44,74 @@ public class ItemAcquireUI : MonoBehaviour
         itemText = itemUIContainer.transform.GetChild(0).gameObject.GetComponent<Text>();
         itemModel = itemUIContainer.transform.GetChild(1).gameObject;
 
-        desiredPosition = new Vector3(itemModel.transform.localPosition.x, itemModel.transform.localPosition.y, itemModel.transform.localPosition.z);
+        desiredItemPosition = new Vector3(itemModel.transform.localPosition.x, itemModel.transform.localPosition.y, itemModel.transform.localPosition.z);
         itemModel.transform.localPosition = new Vector3(0f, 0f, 0f);
         itemText.enabled = false;
         itemText.text = itemName.ToUpper();
 
-        StartCoroutine("InitialRoutine");
-    }
-    void Update()
-    {
-        if (doneInitialRoutine)
-            itemModel.transform.Rotate(0f, 0f, -iconRotationSpeed * Time.deltaTime, Space.Self);
+
+        tapeUIContainer = gameObject.transform.GetChild(1).gameObject;
+        tapeUIContainer.SetActive(true);
+        tapeText = tapeUIContainer.transform.GetChild(0).gameObject.GetComponent<Text>();
+        tapeModel = tapeUIContainer.transform.GetChild(1).gameObject;
+
+        desiredTapePosition = new Vector3(tapeModel.transform.localPosition.x, tapeModel.transform.localPosition.y, tapeModel.transform.localPosition.z);
+        tapeModel.transform.localPosition = new Vector3(0f, 0f, 0f);
+        tapeText.enabled = false;
+        tapeText.text = tapeName.ToUpper();
+
     }
 
-    IEnumerator InitialRoutine()
+    public void GetTape()
     {
-        yield return new WaitForSeconds(waitAtCenterTime);
-        while (itemModel.transform.localPosition != desiredPosition)
+        if (!doneInitialTapeRoutine)
+            StartCoroutine("InitialTapeRoutine");
+    }
+
+    public void GetItem()
+    {
+        if (!doneInitialItemRoutine)
+            StartCoroutine("InitialItemRoutine");
+    }
+
+    void Update()
+    {
+        if (doneInitialItemRoutine)
         {
-            itemModel.transform.localPosition = Vector3.MoveTowards(itemModel.transform.localPosition, desiredPosition, iconSlideSpeed * Time.deltaTime);
+            itemModel.transform.Rotate(0f, 0f, -iconRotationSpeed * Time.deltaTime, Space.Self);
+        }
+        if (doneInitialTapeRoutine)
+        {
+            tapeModel.transform.Rotate(0f, 0f, -iconRotationSpeed * Time.deltaTime, Space.Self);
+        }
+
+    }
+
+    IEnumerator InitialItemRoutine()
+    {
+        Debug.Log("In InitialItemRoutine");
+        Debug.Log("desitredItemPosition:" + desiredItemPosition);
+        yield return new WaitForSeconds(waitAtCenterTime);
+        while (itemModel.transform.localPosition != desiredItemPosition)
+        {
+            itemModel.transform.localPosition = Vector3.MoveTowards(itemModel.transform.localPosition, desiredItemPosition, iconSlideSpeed * Time.deltaTime);
             yield return null;
         }
-        doneInitialRoutine = true;
+        doneInitialItemRoutine = true;
         itemText.enabled = true;
+    }
+
+    IEnumerator InitialTapeRoutine()
+    {
+        Debug.Log("In InitialTapeRoutine");
+        Debug.Log("desireTapePosition:" + desiredTapePosition);
+        yield return new WaitForSeconds(waitAtCenterTime);
+        while (tapeModel.transform.localPosition != desiredTapePosition)
+        {
+            tapeModel.transform.localPosition = Vector3.MoveTowards(tapeModel.transform.localPosition, desiredTapePosition, iconSlideSpeed * Time.deltaTime);
+            yield return null;
+        }
+        doneInitialTapeRoutine = true;
+        tapeText.enabled = true;
     }
 }

--- a/Assets/Scripts/UI/ItemUI.cs
+++ b/Assets/Scripts/UI/ItemUI.cs
@@ -4,25 +4,42 @@
 public class ItemUI : MonoBehaviour
 {
     private GameObject itemUIContainer;
+    private GameObject cassetteUIContainer;
     void Awake()
     {
         itemUIContainer = gameObject.transform.GetChild(0).gameObject;
         itemUIContainer.SetActive(false);
 
-        GetComponent<ItemAcquireUI>().enabled = false;
+        cassetteUIContainer = gameObject.transform.GetChild(1).gameObject;
+        cassetteUIContainer.SetActive(false);
+
+        //GetComponent<ItemAcquireUI>().enabled = false;
     }
 
     public void AcquireItem(string itemName)
     {
         itemUIContainer.SetActive(true);
-        GetComponent<ItemAcquireUI>().enabled = true;
-        GetComponent<ItemAcquireUI>().itemName = itemName;
+        GetComponent<ItemAcquireUI>().GetItem();
+        //GetComponent<ItemAcquireUI>().itemName = itemName;
     }
 
     public void NoItem()
     {
         itemUIContainer.SetActive(false);
-        GetComponent<ItemAcquireUI>().enabled = false;
+        //GetComponent<ItemAcquireUI>().enabled = false;
+    }
+
+    public void AcquireTape(string itemName)
+    {
+        cassetteUIContainer.SetActive(true);
+        GetComponent<ItemAcquireUI>().GetTape();
+        //GetComponent<ItemAcquireUI>().itemName = itemName;
+    }
+
+    public void NoTape()
+    {
+        cassetteUIContainer.SetActive(false);
+        //GetComponent<ItemAcquireUI>().enabled = false;
     }
 
     // Space for functions like UseItem(), etc.


### PR DESCRIPTION
TWO ITEM UI
- There is now a GettableTape prefab and a GettableObj prefab
- There is a Player prefab variant that you should be able to drop in any scene and try to pickup gettable obj and gettable tape
- Once this is merged in, we'll add the ItemUIMain item onto the main player prefab and then it should work in any scene

TODO: 
GettableTape needs a Tape model still! This will be used on the actual pickup, and then the animation to the top of the screen
GettableObj needs a bit more customization still, it is hardcoded to name "KeyCard" for now
Tweak size/speed/position of UI items based on Camera we decide on
Match up rotation of objects?