### PR TITLE
UX fixes

### DIFF
--- a/Assets/Resources/ReturnFromLevel.prefab
+++ b/Assets/Resources/ReturnFromLevel.prefab
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2152303213365831278
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7266156106846279574}
+  - component: {fileID: 6236949330364198326}
+  m_Layer: 0
+  m_Name: ReturnFromLevel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7266156106846279574
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2152303213365831278}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.026721954, y: -23.867542, z: 100}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6236949330364198326
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2152303213365831278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3910e8a793ce184c9373049c27c79c5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/ReturnFromLevel.prefab.meta
+++ b/Assets/Resources/ReturnFromLevel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a876ebc98863aa84780d62dae171f429
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/AlphaTransitions/AlphaIntro.cs
+++ b/Assets/Scenes/AlphaTransitions/AlphaIntro.cs
@@ -48,7 +48,7 @@ public class AlphaIntro : MonoBehaviour
 
     void Update()
     {
-        if (Input.GetButtonDown("Fire1") && readyToStart)
+        if (Input.GetButtonDown("Interact") && readyToStart)
         {
             audioSource.Play();
             promptAnimator.gameObject.SetActive(false);

--- a/Assets/Scenes/AlphaTransitions/AlphaOutro.cs
+++ b/Assets/Scenes/AlphaTransitions/AlphaOutro.cs
@@ -49,7 +49,7 @@ public class AlphaOutro : MonoBehaviour
 
     void Update()
     {
-        if (Input.GetButtonDown("Fire1") && readyToStart)
+        if (Input.GetButtonDown("Interact") && readyToStart)
         {
             audioSource.Play();
             promptAnimator.gameObject.SetActive(false);

--- a/Assets/Scenes/Level 2 Alpha Tylerwork.unity
+++ b/Assets/Scenes/Level 2 Alpha Tylerwork.unity
@@ -499,7 +499,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh21670
+  m_Name: pb_Mesh91358
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -6022,7 +6022,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh18880
+  m_Name: pb_Mesh88566
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -14478,7 +14478,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh20654
+  m_Name: pb_Mesh90340
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -16435,7 +16435,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh21244
+  m_Name: pb_Mesh90930
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -17866,6 +17866,75 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 521754996}
   m_Mesh: {fileID: 3633865748600368068, guid: ee7ec6a8f34d5cf4297d4c7574d0c9d8, type: 3}
+--- !u!1001 &522752941
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4829865603357687804, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_Name
+      value: StateManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 901.33984
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 179.159
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -160.40234
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4829865603357687806, guid: 13660f1b761269446822e04271e491ac,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 13660f1b761269446822e04271e491ac, type: 3}
 --- !u!1 &533349682
 GameObject:
   m_ObjectHideFlags: 0
@@ -44761,7 +44830,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh17484
+  m_Name: pb_Mesh87170
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -46440,6 +46509,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 3bde03a53c93cc24cac3c8871bdeaf68, type: 2}
+    - target: {fileID: 2654804492679217102, guid: 7737647c22c1fc64a88d5cd030c352ce,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5299397951810176211, guid: 7737647c22c1fc64a88d5cd030c352ce,
         type: 3}
       propertyPath: firstbot
@@ -51901,7 +51975,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh18632
+  m_Name: pb_Mesh88318
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -59812,7 +59886,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh19616
+  m_Name: pb_Mesh89302
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2

--- a/Assets/Scripts/UI/DialogManager.cs
+++ b/Assets/Scripts/UI/DialogManager.cs
@@ -103,7 +103,7 @@ public class DialogManager : MonoBehaviour
     bool dialogFinished = true;
     float speed = 0.005f; // Fraction of second delay between characters appearing
 
-    public bool runTest; // DEBUG ONLY
+    public bool runTest = false; // DEBUG ONLY
 
     void Start()
     {
@@ -190,11 +190,17 @@ public class DialogManager : MonoBehaviour
         int curLength = 0;
         for (int p = 0; p < dialog.paragraphs.Length; p++)
         {
+            dialogNext = false;
             dialogBox.AddParagraph(dialog, p);
             for (int i = 0; i <= dialog.paragraphs[p].Length; i++)
             {
                 dialogBox.paragraphs.maxVisibleCharacters = curLength + i;
                 yield return new WaitForSeconds(speed);
+                if (dialogNext)
+                {
+                    dialogBox.paragraphs.maxVisibleCharacters = curLength + dialog.paragraphs[p].Length;
+                    break;
+                }
             }
             dialogBox.ShowPrompt();
             dialogNext = false;

--- a/Assets/Scripts/UI/MainMenuManager.cs
+++ b/Assets/Scripts/UI/MainMenuManager.cs
@@ -82,8 +82,8 @@ public class MainMenuManager : MonoBehaviour
         if (isInteractable)
             RotateButtons();
 
-        // Check for skipping (Start or Enter)
-        if (Input.GetButtonDown("Start") && !skipIntro)
+        // Check for skipping
+        if ((Input.GetButtonDown("Start") || Input.GetKeyDown(KeyCode.Escape)) && !skipIntro)
         {
             skipIntro = true;
             StartCoroutine(QuickStart());

--- a/Assets/Scripts/UI/PauseMenuManager.cs
+++ b/Assets/Scripts/UI/PauseMenuManager.cs
@@ -19,7 +19,7 @@ public class PauseMenuManager : MonoBehaviour
     private bool isInteractable = false;
     private Button[] buttons;
     private Button selected;
-    
+
     public AudioSource clickSound;
     public AudioSource hoverSound;
 
@@ -70,6 +70,8 @@ public class PauseMenuManager : MonoBehaviour
     public void QuitGame()
     {
         Time.timeScale = 1; // reset timeScale before we leave scene!
+        // Create return from level indicator object
+        GameObject.Instantiate(Resources.Load("ReturnFromLevel"), Vector3.zero, Quaternion.identity);
         SceneManager.LoadScene(0);
     }
 

--- a/Assets/Scripts/UI/ReturnFromLevel.cs
+++ b/Assets/Scripts/UI/ReturnFromLevel.cs
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+/// <summary>
+/// Super simple monobehaviour to get passed from a QUIT in a level
+/// to the main menu, to indicate that we just came from a level.
+/// Right now does literally nothing else, could do more if needed later.
+/// </summary>
+public class ReturnFromLevel : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        DontDestroyOnLoad(this.gameObject);
+    }
+}

--- a/Assets/Scripts/UI/ReturnFromLevel.cs.meta
+++ b/Assets/Scripts/UI/ReturnFromLevel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3910e8a793ce184c9373049c27c79c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI/Animations/SkipIntro.anim
+++ b/Assets/UI/Animations/SkipIntro.anim
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkipIntro
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 1574349066
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/UI/Animations/SkipIntro.anim.meta
+++ b/Assets/UI/Animations/SkipIntro.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4c7d462333e4f54d9f614323d17f6ba
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI/Animations/Transition.controller
+++ b/Assets/UI/Animations/Transition.controller
@@ -44,6 +44,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: 300962489858049262}
     m_Position: {x: 30, y: 200, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 36224099235998145}
+    m_Position: {x: 150, y: 280, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -54,6 +57,56 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 300962489858049262}
+--- !u!1101 &-4924748711285440801
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: StartNewGame
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6415388966531963054}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-939709674913155566
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: SkipIntro
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 36224099235998145}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.96875
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -68,7 +121,13 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: SkipIntro
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -82,6 +141,33 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1102 &36224099235998145
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SkipIntro
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -4924748711285440801}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: c4c7d462333e4f54d9f614323d17f6ba, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &263898852059704952
 AnimatorState:
   serializedVersion: 5
@@ -120,6 +206,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 922318903051315194}
+  - {fileID: -939709674913155566}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -604,7 +604,7 @@ InputManager:
     negativeButton: 
     positiveButton: joystick button 7
     altNegativeButton: 
-    altPositiveButton: return
+    altPositiveButton: 
     gravity: 1000
     dead: 0.01
     sensitivity: 10

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -604,7 +604,7 @@ InputManager:
     negativeButton: 
     positiveButton: joystick button 7
     altNegativeButton: 
-    altPositiveButton: 
+    altPositiveButton: return
     gravity: 1000
     dead: 0.01
     sensitivity: 10


### PR DESCRIPTION
- Can skip intro to main menu now by pressing Start (controller) or Esc (kbd)
- When returning from a level after hitting QUIT in the pause menu, the intro should also be skipped.
- You can now skip through paragraphs quickly in dialogs by hitting A before the paragraph has fully shown up. Since we don't have any other dialogs in yet, test this in the DialogSystemTest scene.