### PR TITLE
Scene loader implemented, added to necessities prefab

### DIFF
--- a/Assets/Plugins/Demigiant/DOTween/DOTween.dll.mdb.meta
+++ b/Assets/Plugins/Demigiant/DOTween/DOTween.dll.mdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4f007001a22b3d24dae350342c4d19c8
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Demigiant/DOTween/Editor/DOTweenEditor.dll.mdb.meta
+++ b/Assets/Plugins/Demigiant/DOTween/Editor/DOTweenEditor.dll.mdb.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8f46310a8b0a8f04a92993c37c713243
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Final Prefabs/Necessities.prefab
+++ b/Assets/Prefabs/Final Prefabs/Necessities.prefab
@@ -37,9 +37,95 @@ Transform:
   - {fileID: 5353534937229607548}
   - {fileID: 5410940197093107029}
   - {fileID: 2006946491701090555}
+  - {fileID: 7218399684044112319}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &133146498919755898
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 735452574007421440}
+    m_Modifications:
+    - target: {fileID: 1197355946096333830, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2468610676597200386, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_Name
+      value: SceneLoader
+      objectReference: {fileID: 0}
+    - target: {fileID: 7019111676795150292, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_Alpha
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28.609905
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -31.097738
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 84.763306
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c71382154ccea143a0f583dafd07551, type: 3}
+--- !u!4 &7218399684044112319 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7347024991076954565, guid: 0c71382154ccea143a0f583dafd07551,
+    type: 3}
+  m_PrefabInstance: {fileID: 133146498919755898}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1557196425342529420
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -202,6 +288,46 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 735452574007421440}
     m_Modifications:
+    - target: {fileID: 436657370143678882, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657370143678882, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -1.0899658
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657370143678882, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -2.184143
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657370143678882, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -360
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657370259073723, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657370259073723, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -0.0009765625
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657370259073723, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 3.81781
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657370259073723, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 436657371234006708, guid: c487e5ca662376146afd1f95e051187e,
         type: 3}
       propertyPath: m_Name
@@ -310,6 +436,26 @@ PrefabInstance:
     - target: {fileID: 436657371234006711, guid: c487e5ca662376146afd1f95e051187e,
         type: 3}
       propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657371629809162, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657371629809162, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.0007324219
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657371629809162, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1.81781
+      objectReference: {fileID: 0}
+    - target: {fileID: 436657371629809162, guid: c487e5ca662376146afd1f95e051187e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/Assets/Prefabs/SceneLoader.prefab
+++ b/Assets/Prefabs/SceneLoader.prefab
@@ -1,0 +1,234 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2468610676597200386
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7347024991076954565}
+  - component: {fileID: 3269515287967061371}
+  m_Layer: 0
+  m_Name: SceneLoader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7347024991076954565
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2468610676597200386}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 28.609905, y: -31.097738, z: 84.763306}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1197355946096333830}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3269515287967061371
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2468610676597200386}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed109f9ff5483b3419c25c478019ce76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fadeInOnSceneStart: 1
+  fadeInDuration: 1
+--- !u!1 &2648458948853934885
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1197355946096333830}
+  - component: {fileID: 3571709373300943444}
+  - component: {fileID: 3066281617061829009}
+  - component: {fileID: 4466177592893721274}
+  - component: {fileID: 7019111676795150292}
+  m_Layer: 0
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1197355946096333830
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2648458948853934885}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 4308306676058479425}
+  m_Father: {fileID: 7347024991076954565}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &3571709373300943444
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2648458948853934885}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 1
+  m_TargetDisplay: 0
+--- !u!114 &3066281617061829009
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2648458948853934885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &4466177592893721274
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2648458948853934885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!225 &7019111676795150292
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2648458948853934885}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!1 &7350343883050609873
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4308306676058479425}
+  - component: {fileID: 1897317880543642608}
+  - component: {fileID: 4403779360605649870}
+  m_Layer: 0
+  m_Name: Black
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4308306676058479425
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7350343883050609873}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1197355946096333830}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1897317880543642608
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7350343883050609873}
+  m_CullTransparentMesh: 0
+--- !u!114 &4403779360605649870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7350343883050609873}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Prefabs/SceneLoader.prefab.meta
+++ b/Assets/Prefabs/SceneLoader.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c71382154ccea143a0f583dafd07551
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/SceneLoader.cs
+++ b/Assets/Scripts/Game/SceneLoader.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using DG.Tweening;
+
+public class SceneLoader : MonoBehaviour
+{
+    StateManager stateManager;
+    CanvasGroup canvasGroup;
+
+    [Header("Fade in from black on scene start?")]
+    public bool fadeInOnSceneStart = true;
+    public float fadeInDuration = 1f;
+
+    void Awake()
+    {
+        stateManager = FindObjectOfType<StateManager>();
+        canvasGroup = transform.GetChild(0).gameObject.GetComponent<CanvasGroup>();
+        canvasGroup.alpha = 0f;
+    }
+
+    void Start()
+    {
+        if (fadeInOnSceneStart)
+            canvasGroup.DOFade(0f, fadeInDuration).From(1f);
+    }
+
+    /// <summary>
+    /// Calling this will take control away from player, fade to black and
+    /// then load the next scene in the build order.
+    /// </summary>
+    public void LoadNextScene(float fadeDuration = 1f)
+    {
+        stateManager.SetState(StateManager.State.Inert);
+
+        StartCoroutine(LoadNextSceneProcess(fadeDuration));
+    }
+
+    IEnumerator LoadNextSceneProcess(float fadeDuration)
+    {
+        Tween t = canvasGroup.DOFade(1f, fadeDuration);
+        yield return new WaitWhile(() => t != null && t.IsPlaying());
+        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex + 1);
+    }
+}

--- a/Assets/Scripts/Game/SceneLoader.cs.meta
+++ b/Assets/Scripts/Game/SceneLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed109f9ff5483b3419c25c478019ce76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Should be automatically in your scene once you update due to it being a part of the necessities prefab (so no need to add it to your scene).

Simply use: `FindObjectOfType<SceneLoader>().LoadNextScene();` to get control taken away, fade to black, load next scene in build order functionality.

By default the fade to black time is 1 second when no arguments are given. If you give an argument like `LoadNextScene(4.5f)` then the fade will take 4.5 seconds instead.

The SceneLoader also has checkbox and field in the inspector if you want the scene to START with a fade-in from black, and you can specify how long it is. By default it *does* start with a 1sec fade in (control not taken away during scene starts - I figure we might have special events we cook up later that would otherwise conflict)