### PR TITLE
Spin out tape dialog

### DIFF
--- a/Assets/Prefabs/LevelTapeDialog.prefab
+++ b/Assets/Prefabs/LevelTapeDialog.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &7773374854374719519
+--- !u!1 &6691278675263197415
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,39 +8,38 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7773374854374719517}
-  - component: {fileID: 7773374854374719516}
+  - component: {fileID: 6691278675263197401}
+  - component: {fileID: 6691278675263197400}
   m_Layer: 0
-  m_Name: DialogManager
-  m_TagString: Untagged
+  m_Name: LevelTapeDialog
+  m_TagString: DialogText
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7773374854374719517
+--- !u!4 &6691278675263197401
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7773374854374719519}
+  m_GameObject: {fileID: 6691278675263197415}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 901.33984, y: 179.159, z: -160.40234}
+  m_LocalPosition: {x: 8.5, y: 1, z: 6.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7773374854374719516
+--- !u!114 &6691278675263197400
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7773374854374719519}
+  m_GameObject: {fileID: 6691278675263197415}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 98dccd03d8350a9438c8e6d1bcf499c2, type: 3}
+  m_Script: {fileID: 11500000, guid: 0a8a35dfe3d9bac468781a09f0158596, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  runTest: 0

--- a/Assets/Prefabs/LevelTapeDialog.prefab.meta
+++ b/Assets/Prefabs/LevelTapeDialog.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b85c0637225acff458a790ea50f0a1ac
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/DialogManager.cs
+++ b/Assets/Scripts/UI/DialogManager.cs
@@ -121,7 +121,7 @@ public class DialogManager : MonoBehaviour
 
         dialogBox.Disable();
 
-        dialogTextManager = GetComponent<DialogTextManager>();
+        dialogTextManager = GameObject.FindGameObjectWithTag("DialogText").GetComponent<DialogTextManager>();
 
         if (runTest)
             StartCoroutine(Test());

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -16,6 +16,7 @@ TagManager:
   - VHSPauseEffect
   - PauseMenu
   - Music
+  - DialogText
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Spin level text dialog out of DialogManager
- Drop LevelTapeDialog prefab into scene and edit that as per instructions in Dev Docs to edit tape dialog per scene
- Keep Necessities nice and clean!