### PR TITLE
Camera screen shake function + necessities prefab fix

### DIFF
--- a/Assets/Scripts/UI/DialogManager.cs
+++ b/Assets/Scripts/UI/DialogManager.cs
@@ -121,7 +121,9 @@ public class DialogManager : MonoBehaviour
 
         dialogBox.Disable();
 
-        dialogTextManager = GameObject.FindGameObjectWithTag("DialogText").GetComponent<DialogTextManager>();
+        GameObject dialogText = GameObject.FindGameObjectWithTag("DialogText");
+        if (dialogText != null)
+            dialogTextManager = dialogText.GetComponent<DialogTextManager>();
 
         if (runTest)
             StartCoroutine(Test());


### PR DESCRIPTION
#### Test in any scene with the camera - because you must call this function, if you want to test it quickly, open the cameracontrol script on the camera object and uncomment the update function, then you can just press K to test the screenshake, but only on default values.

- We now have a statically available screenshake on the camera! We can use it for special effects, explosions, rumblings near the engine, landing from flips, crates hitting the ground, etc, whatever we like!
- Easy to call, and three ways to do so. **Requires no reference to the camera object, this is a static object, call it from any script! Safe to call multiple times: will never overlap, always replaces the last call.**
    - CameraControl.CC.ScreenShake() --> Shake with a default intensity of 1 and duration of 1.
    - CameraControl.CC.ScreenShake(float intensity); --> Shake with your desired intensity, duration of 1.
    - CameraControl.CC.ScreenShake(float intensity, float duration); --> Shake with desired intensity and duration!
    - Intensity dies off linearly over the course of the duration.
- Fixed a dependency in the dialog manager in the necessities prefab which looks for tape texts. Now if it can't find them, it doesn't give any errors, so necessities prefab is always run-safe.