### PR TITLE
fix tweening warnings

### DIFF
--- a/Assets/Scripts/CheckPoint.cs
+++ b/Assets/Scripts/CheckPoint.cs
@@ -29,7 +29,7 @@ public class CheckPoint : MonoBehaviour
     {
         float fadeInDuration = FindObjectOfType<SceneLoader>().startFadeDuration;
         Tween t = text.DOFade(1f, fadeInDuration).SetEase(Ease.InExpo);
-        yield return new WaitWhile(() => t != null && t.IsPlaying());
+        yield return t.WaitForCompletion();
         for (int i = 0; i < 3; i++)
         {
             text.maxVisibleCharacters = 6;
@@ -42,8 +42,7 @@ public class CheckPoint : MonoBehaviour
             yield return new WaitForSecondsRealtime(0.08f);
         }
         t = text.DOFade(0f, 1f);
-        yield return new WaitWhile(() => t != null && t.IsPlaying());
-
+        yield return t.WaitForCompletion();
         // Disable the whole canvas object at the end.
         canvas.SetActive(false);
     }

--- a/Assets/Scripts/Game/SceneLoader.cs
+++ b/Assets/Scripts/Game/SceneLoader.cs
@@ -94,7 +94,7 @@ public class SceneLoader : MonoBehaviour
                     pair.Item1.DOFade(0f, endFadeDuration);
                 }
             }
-            yield return new WaitWhile(() => t != null && t.IsPlaying());
+            yield return t.WaitForCompletion();
         }
         SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex + 1);
     }
@@ -112,7 +112,7 @@ public class SceneLoader : MonoBehaviour
                     pair.Item1.DOFade(0f, endFadeDuration);
                 }
             }
-            yield return new WaitWhile(() => t != null && t.IsPlaying());
+            yield return t.WaitForCompletion();
         }
         SceneManager.LoadScene(buildIndex);
     }

--- a/Assets/Scripts/LiftAction.cs
+++ b/Assets/Scripts/LiftAction.cs
@@ -47,7 +47,8 @@ public class LiftAction : MonoBehaviour, IObjectAction
 
     IEnumerator WaitForLift(Tween liftMovement)
     {
-        yield return new WaitWhile(() => liftMovement != null && liftMovement.IsPlaying());
+        //yield return new WaitWhile(() => liftMovement != null && liftMovement.IsPlaying());
+        yield return liftMovement.WaitForCompletion();
         allowUse = true;
     }
 

--- a/Assets/Scripts/OcclusionVolume.cs
+++ b/Assets/Scripts/OcclusionVolume.cs
@@ -194,7 +194,7 @@ public class OcclusionVolume : MonoBehaviour
         {
             Tween lightFade = HideLights();
             if (lightFade != null)
-                yield return new WaitWhile(() => lightFade != null & lightFade.IsPlaying());
+                yield return new WaitWhile(() => lightFade.IsComplete());
         }
         // HideLevelColliders();
         if (hideInteriorObjects) HideInteriorObjects();

--- a/Assets/Scripts/UI/DialogManager.cs
+++ b/Assets/Scripts/UI/DialogManager.cs
@@ -201,7 +201,8 @@ public class DialogManager : MonoBehaviour
         dialogFinished = false;
         audioSource.PlayOneShot(startClip);
         Tween setup = dialogBox.SetUp();
-        yield return new WaitWhile(() => setup != null && setup.IsPlaying());
+        //yield return new WaitWhile(() => setup != null && setup.IsPlaying());
+        yield return setup.WaitForCompletion();
 
         // STEP 2 : Fade in the headers one by one.
         dialogBox.header.text = dialog.header;

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -118,7 +118,7 @@ public class UIManager : MonoBehaviour
         if (prompt.fadeTween != null) prompt.fadeTween.Kill();
         prompt.fadeTween = prompt.canvasGroup.DOFade(0f, promptFadeTime).From(prompt.canvasGroup.alpha);
 
-        while (prompt.fadeTween != null & prompt.fadeTween.IsPlaying())
+        while (prompt.fadeTween.IsActive()) // hmm, how to fix this one?
         {
             Vector3 pos = GetPromptPosition(prompt.character);
             prompt.rectTransform.position = pos;


### PR DESCRIPTION
- Fixes most warnings related to attempting to access killed tweens

- Still one left that I pushed to another trello card since it seems to be a bit more complicated of a fix and might touch multiple scripts, so probably best to do in a separate PR
