### PR TITLE
attach grav watch to kira

### DIFF
--- a/Assets/Prefabs/Final Prefabs/Player.prefab
+++ b/Assets/Prefabs/Final Prefabs/Player.prefab
@@ -2961,37 +2961,37 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.02
+      value: -0.0159
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.02
+      value: -0.0202
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.01
+      value: -0.0121
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7066876
+      value: -0.7233125
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.12053342
+      value: 0.17424956
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.23115867
+      value: 0.17222233
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.6577462
+      value: 0.6455972
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
@@ -3001,17 +3001,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -80.186005
+      value: -83.698006
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -99.411
+      value: -167.291
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 128.319
+      value: 195.698
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
         type: 3}

--- a/Assets/Prefabs/Final Prefabs/Player.prefab
+++ b/Assets/Prefabs/Final Prefabs/Player.prefab
@@ -2945,6 +2945,101 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 770675801537279796}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &770675801536884130 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400022, guid: 535156c74f90dde48be444746515be0d,
+    type: 3}
+  m_PrefabInstance: {fileID: 770675801537279796}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1259674489445218995
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 770675801536884130}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7066876
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.12053342
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.23115867
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6577462
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -80.186005
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -99.411
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 128.319
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.001
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.001
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_Name
+      value: GetHomewatch
+      objectReference: {fileID: 0}
+    - target: {fileID: 5913876964564614686, guid: 810800c0d4b0ce04c9e25b37f8d04aec,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: ae7fe1175e0461741a7e853d2ab96db5, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 810800c0d4b0ce04c9e25b37f8d04aec, type: 3}
 --- !u!1001 &1607966512193181118
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GravityWatch.cs
+++ b/Assets/Scripts/GravityWatch.cs
@@ -3,10 +3,13 @@
 public class GravityWatch : MonoBehaviour
 {
     GravityManager gravityManager;
+    GameObject gwatch;
 
     void Awake()
     {
         gravityManager = FindObjectOfType<GravityManager>();
+        gwatch = GameObject.Find("GetHomewatch");
+        gwatch.SetActive(false);
     }
 
     void Start()
@@ -18,6 +21,7 @@ public class GravityWatch : MonoBehaviour
     {
         if (collision.gameObject.tag == "Player")
         {
+            gwatch.SetActive(true);
             gravityManager.haveGravWatch = true;
             FindObjectOfType<TutorialScreen>().StartTutorial();
             // Destroy(this.gameObject);

--- a/Assets/props/GravLit.mat
+++ b/Assets/props/GravLit.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New Material
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/props/GravLit.mat
+++ b/Assets/props/GravLit.mat
@@ -7,10 +7,10 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: New Material
+  m_Name: GravLit
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
+  m_ShaderKeywords: _EMISSION _METALLICGLOSSMAP _NORMALMAP
+  m_LightmapFlags: 2
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
@@ -20,7 +20,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _BumpMap:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 2e958ab839482284db3c8b2223d60206, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:
@@ -36,15 +36,15 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _EmissionMap:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 0674dabc7424ca34db7179fcb82cecca, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: e25596864f8a9e2469c2ae27f9acd93c, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 6ac55bc785b410d4d8495948924186be, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _OcclusionMap:
@@ -74,4 +74,4 @@ Material:
     - _ZWrite: 1
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/props/GravLit.mat.meta
+++ b/Assets/props/GravLit.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae7fe1175e0461741a7e853d2ab96db5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Once Kira collects the grav watch, it will be on her wrist for the rest of the game
- If the grav watch is present on a level, the model will be inactive until the watch is picked up. Try it out on 1-1
- otherwise, Kira will have the grav watch attached to her wrist. Childed to her bone so it follows her movement pretty well, try it out on other levels!
- Pretty hard to tell what it is, but the emissive texture def. looks like something around her wrist. Will prob make more sense once the 'use gravity watch' animation is implemented
- hopefully they animate her using it on her right hand, that's where most righties wear a watch right? Knowing our luck, Kira is left-handed though 👍 