### PR TITLE
crates not blocked by floppy props

### DIFF
--- a/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
+++ b/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
@@ -549,7 +549,7 @@ public class ThirdPersonUserControl : MonoBehaviour
                 {
                     foreach (Collider c in hitColliders)
                     {
-                        if (c.gameObject.CompareTag("Player") || c.gameObject.CompareTag("robot") || c.gameObject == this.gameObject)
+                        if (c.gameObject.CompareTag("Player") || c.gameObject.CompareTag("robot") || c.gameObject == this.gameObject || c.gameObject.CompareTag("FloppyProps"))
                         {
                             // Ignore player, robot, and ourselves
                             continue;

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -18,6 +18,7 @@ TagManager:
   - Music
   - DialogText
   - KiraWatch
+  - FloppyProps
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
This needs a full game pass to work properly in all situations, basically all floppy props just need to be given the FloppyProps tag.
To try out, add the FloppyProps tag to the pylons in the first room and then watch in wonderment and amazfulness as Kira/Cas/Ethan can push/pull crates ALL over those pylons!