### PR TITLE
small fixes

### DIFF
--- a/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
+++ b/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
@@ -152,7 +152,7 @@ public class ThirdPersonUserControl : MonoBehaviour
         }
 
         // always check for pause menu, no matter the state
-        if (Input.GetButtonDown("Start") || Input.GetKeyDown(KeyCode.P))
+        if (Input.GetButtonDown("Start") || Input.GetKeyDown(KeyCode.P) || Input.GetKeyDown(KeyCode.Escape))
         {
             isPaused = !isPaused;
             if (isPaused)
@@ -282,10 +282,7 @@ public class ThirdPersonUserControl : MonoBehaviour
         // this eventually will kick to main menu or something instead
 
 
-        if (Input.GetKeyDown(KeyCode.Escape))
-        {
-            Application.Quit();
-        }
+
 
         if (Input.GetKey(KeyCode.N) && Input.GetKey(KeyCode.M))
         {

--- a/Assets/Prefabs/DialogManager.prefab
+++ b/Assets/Prefabs/DialogManager.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 7773374854374719517}
   - component: {fileID: 7773374854374719516}
   - component: {fileID: 509471916550902971}
+  - component: {fileID: 7627658440499241645}
   m_Layer: 0
   m_Name: DialogManager
   m_TagString: Untagged
@@ -63,6 +64,102 @@ AudioSource:
   m_Volume: 1
   m_Pitch: 1
   Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!82 &7627658440499241645
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7773374854374719519}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 8300000, guid: e6b5ad25332b4e54f8a6f3d1d56ce276, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 0.295
+  m_Pitch: 1.22
+  Loop: 1
   Mute: 0
   Spatialize: 0
   SpatializePostEffects: 0

--- a/Assets/Scripts/Gravity/GravityManager.cs
+++ b/Assets/Scripts/Gravity/GravityManager.cs
@@ -48,6 +48,8 @@ public class GravityManager : MonoBehaviour
 
     void Start()
     {
+
+
         // Get the post-processing volume component.
         postProcessVolume = GetComponent<PostProcessVolume>();
 
@@ -78,6 +80,10 @@ public class GravityManager : MonoBehaviour
 
         // Collect all the no-flip-zones in the scene now for checking later.
         noFlipZones = NoFlipZone.FindObjectsOfType(typeof(NoFlipZone)) as NoFlipZone[];
+
+        // Reset gravity when level resets, just in case things get jank
+        Physics.gravity = new Vector3(0, -9.8f, 0);
+
     }
 
     void Update()

--- a/Assets/Scripts/RobotBuddy.cs
+++ b/Assets/Scripts/RobotBuddy.cs
@@ -173,7 +173,10 @@ public class RobotBuddy : MonoBehaviour
         if (stateManager.CheckReadyToFlip())
         {
             Vector3 newForwardLook = new Vector3(roboSpotlight.transform.forward.x, 0, roboSpotlight.transform.forward.z);
-            roboBody.transform.forward = newForwardLook; //roboSpotlight.transform.forward;
+            if ((newForwardLook.sqrMagnitude > 0.01f))
+            {
+                roboBody.transform.forward = newForwardLook;
+            }
         }
         // We don't want to get pushed around by the player
     }

--- a/Assets/Scripts/UI/DialogManager.cs
+++ b/Assets/Scripts/UI/DialogManager.cs
@@ -112,6 +112,7 @@ public class DialogManager : MonoBehaviour
     public bool runTest = false; // DEBUG ONLY
 
     AudioSource audioSource;
+    AudioSource hiss;
     public AudioClip startClip;
     public AudioClip nextClip;
     public AudioClip finishClip;
@@ -119,7 +120,8 @@ public class DialogManager : MonoBehaviour
     void Start()
     {
         stateManager = GameObject.FindObjectOfType<StateManager>();
-        audioSource = GetComponent<AudioSource>();
+        audioSource = GetComponents<AudioSource>()[0];
+        hiss = GetComponents<AudioSource>()[1];
 
         dialogBox = new DialogBox();
         dialogBox.canvasGroup = GameObject.Find("DialogBox").GetComponent<CanvasGroup>();
@@ -200,6 +202,7 @@ public class DialogManager : MonoBehaviour
         // STEP 1 : Fade box in
         dialogFinished = false;
         audioSource.PlayOneShot(startClip);
+        hiss.Play();
         Tween setup = dialogBox.SetUp();
         //yield return new WaitWhile(() => setup != null && setup.IsPlaying());
         yield return setup.WaitForCompletion();
@@ -243,6 +246,7 @@ public class DialogManager : MonoBehaviour
         // STEP 4 : Finish, tear down dialog box, reset state to Normal.
         dialogBox.TearDown();
         dialogFinished = true;
+        hiss.Stop();
         audioSource.PlayOneShot(finishClip);
         stateManager.SetState(StateManager.State.Normal);
     }


### PR DESCRIPTION
slowly making the way through the to do list, subbing in little chunks so if anything breaks, it should be able to triage/roll  back any problems
this PR contains:
- escape key will launch pause menu instead of shut game down entirely
- global gravity is reset at start of each level, just in case gravity breaks again
- there is tape hiss playing while dialog box is up now
- fixed a bug with robot buddy throwing zero look rotation vector warnings at the start of 1-2 before he was collected