### PR TITLE
Elevator fixes

### DIFF
--- a/Assets/Prefabs/EOLElevator.prefab
+++ b/Assets/Prefabs/EOLElevator.prefab
@@ -1,5 +1,119 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &290418426230166509
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 290418426230166508}
+  - component: {fileID: 290418426230166512}
+  - component: {fileID: 290418426230166513}
+  - component: {fileID: 290418426230166514}
+  - component: {fileID: 7540879220119762574}
+  - component: {fileID: 3517587937217000156}
+  - component: {fileID: 3517587937217000150}
+  m_Layer: 11
+  m_Name: EOLTrigger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &290418426230166508
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 290418426230166509}
+  m_LocalRotation: {x: -0, y: 0.70710593, z: -0, w: 0.7071077}
+  m_LocalPosition: {x: 2.0039978, y: -0.2, z: -3.9970016}
+  m_LocalScale: {x: 6.9013896, y: 1, z: 3.4793289}
+  m_Children: []
+  m_Father: {fileID: 4629131395787125309}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 90.00001, z: 0}
+--- !u!33 &290418426230166512
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 290418426230166509}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &290418426230166513
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 290418426230166509}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 1f33a649440360348bc40cd9e32ac15f, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &290418426230166514
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 290418426230166509}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &7540879220119762574
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 290418426230166509}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed31ddd3f4a0a6f40bc8a98f8b28caed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  toChangeObject: {fileID: 290418426230166509}
+  triggerEffects: {fileID: 0}
+  persist: 1
+  humanCanInteract: 1
+  robotCanInteract: 0
+  interactText: Descend Elevator
 --- !u!82 &3517587937217000156
 AudioSource:
   m_ObjectHideFlags: 0
@@ -236,114 +350,3 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
---- !u!1001 &3517587937217000148
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 4629131395787125309}
-    m_Modifications:
-    - target: {fileID: 3807579709716947239, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: toChangeObject
-      value: 
-      objectReference: {fileID: 290418426230166509}
-    - target: {fileID: 3807579709716947239, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: robotCanInteract
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947239, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: interactText
-      value: Descend Elevator
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2.0039978
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.4119997
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -3.9970016
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.70710593
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071077
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 90.00001
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 6.9013896
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 3.4793289
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.8232483
-      objectReference: {fileID: 0}
-    - target: {fileID: 3807579709716947257, guid: 0df4055e947550342b3da7a3af8637f9,
-        type: 3}
-      propertyPath: m_Name
-      value: EOLTrigger
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0df4055e947550342b3da7a3af8637f9, type: 3}
---- !u!1 &290418426230166509 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3807579709716947257, guid: 0df4055e947550342b3da7a3af8637f9,
-    type: 3}
-  m_PrefabInstance: {fileID: 3517587937217000148}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &290418426230166508 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3807579709716947256, guid: 0df4055e947550342b3da7a3af8637f9,
-    type: 3}
-  m_PrefabInstance: {fileID: 3517587937217000148}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scripts/ElevatorTrigger.cs
+++ b/Assets/Scripts/ElevatorTrigger.cs
@@ -1,0 +1,154 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+
+public class ElevatorTrigger : MonoBehaviour
+{
+    StateManager stateManager;
+    UIManager uiManager;
+    ThirdPersonUserControl thirdPersonUserControl;
+    ThirdPersonCharacter playerChar;
+    Collider thisCollider;
+
+    public GameObject toChangeObject;
+    public GameObject triggerEffects;
+    public bool persist = true;
+    private AudioSource audios;
+
+    bool inTrigger;
+    // public GameObject prompt;
+
+    [Header("Who can interact with this trigger? Pick one only.")]
+    public bool humanCanInteract = false;
+    public bool robotCanInteract = false;
+    [Header("What text (if any) will show on this trigger's UI prompt?")]
+    public string interactText = "";
+    string interactableTag = "";
+
+    void Start()
+    {
+        // prompt.SetActive(false);
+
+        stateManager = FindObjectOfType<StateManager>();
+        uiManager = FindObjectOfType<UIManager>();
+        thirdPersonUserControl = FindObjectOfType<ThirdPersonUserControl>();
+        playerChar = FindObjectOfType<ThirdPersonCharacter>();
+        thirdPersonUserControl.OnSwitchChar += HandleSwitchChar;
+
+        thisCollider = GetComponent<Collider>();
+        audios = GetComponent<AudioSource>();
+
+
+        if (humanCanInteract && robotCanInteract)
+        {
+            interactableTag = "Player";
+        }
+        else if (humanCanInteract)
+        {
+            interactableTag = "Player";
+        }
+        else if (robotCanInteract)
+        {
+            interactableTag = "robot";
+        }
+        else
+        {
+
+        }
+    }
+
+    void Update()
+    {
+        if (inTrigger && stateManager.GetState() == StateManager.State.Normal && !stateManager.IsGravityFlipped() && playerChar.m_IsGrounded)
+        {
+            //take keypress
+            if (Input.GetButtonDown("Interact") || Input.GetKeyDown(KeyCode.E))
+            {
+                if (!toChangeObject)    // if we don't have an object, don't do anything
+                {
+                    return;
+                }
+
+                //GetComponent<AudioSource>()?.Play();    // Play a sound if one has been added.
+                if (audios) audios.Play();
+
+                MonoBehaviour[] list = toChangeObject.gameObject.GetComponents<MonoBehaviour>();
+                foreach (MonoBehaviour mb in list)
+                {
+                    if (mb is IObjectAction)
+                    {
+                        IObjectAction actor = (IObjectAction)mb;
+                        actor.action();
+                    }
+                }
+
+                if (!persist)
+                {
+                    StartCoroutine("destroyTrigger");
+                }
+            }
+        }
+    }
+
+    IEnumerator destroyTrigger()
+    {
+        ExitRange(interactableTag);
+        if (audios)
+            yield return new WaitForSecondsRealtime(audios.clip.length);
+        if (triggerEffects)
+            Destroy(triggerEffects);
+        Destroy(this.gameObject);
+    }
+
+    // On a char switch, manually check intersection with the trigger.
+    void HandleSwitchChar(object sender, ThirdPersonUserControl.SwitchCharArgs args)
+    {
+        GameObject selected = args.selected;
+        if (selected.tag == "Player") ExitRange("robot");
+        else ExitRange("Player");
+
+        if (selected.tag == interactableTag &&
+        selected.GetComponent<CapsuleCollider>().bounds.Intersects(thisCollider.bounds))
+        {
+            EnterRange(selected.tag);
+        }
+    }
+
+    void OnTriggerEnter(Collider other)
+    {
+        if (!inTrigger && other.tag == interactableTag &&
+            stateManager.GetSelected() == other.gameObject && !stateManager.IsGravityFlipped() && playerChar.m_IsGrounded)
+        {
+            EnterRange(other.tag);
+        }
+
+    }
+
+    void OnTriggerExit(Collider other)
+    {
+        if (inTrigger && other.tag == interactableTag)
+        {
+            ExitRange(other.tag);
+        }
+    }
+
+    void EnterRange(string tag)
+    {
+        inTrigger = true;
+        uiManager.EnterRange(tag, interactText);
+        // prompt.SetActive(true);
+    }
+
+    public void ExitRange(string tag)
+    {
+        inTrigger = false;
+        uiManager.ExitRange(tag);
+        // prompt.SetActive(false);
+    }
+
+    void OnDestroy()
+    {
+        thirdPersonUserControl.OnSwitchChar -= HandleSwitchChar;
+    }
+}

--- a/Assets/Scripts/ElevatorTrigger.cs.meta
+++ b/Assets/Scripts/ElevatorTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed31ddd3f4a0a6f40bc8a98f8b28caed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Player now needs to be grounded and gravity needs to be unflipped for the elevator to be usable. The trigger is also moved closer to the ground.

There was an extra trigger.meta file that showed up as changed even though I didn't change trigger in this commit? I added it in a separate commit so if it seems to be causing trouble, we can just remove that commit. let me know.