### PR TITLE
Only robot and floppy props will stack on crate now

### DIFF
--- a/Assets/Scripts/BoxStacking.cs
+++ b/Assets/Scripts/BoxStacking.cs
@@ -18,7 +18,9 @@ public class BoxStacking : MonoBehaviour
         {
             return; // Ignore the player! We don't ever want to stack them on the crate!
         }
-        if (collision.transform.position.y > transform.position.y)
+
+        if ((collision.gameObject.tag != "robot" || collision.gameObject.tag != "FloppyProps") 
+            && collision.transform.position.y > transform.position.y)
         {
             childobjects.Add(collision.gameObject);
         }


### PR DESCRIPTION
Only robot and floppy prop should stack on crate now, so this should fix the "in-game level editing" bug. I couldn't replicate it so couldn't really test, but this patch means ONLY the robot and floppy props should be able to be stackable now. 
NOTE: If we want to do the "crate on crate" stacking puzzle, we'll just have to add an extra check for crate stacking here and tag the crates appropriately, but since that didn't make it into the game yet, I didn't implement it yet.