### PR TITLE
disallow char switch + recall during pause

### DIFF
--- a/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
+++ b/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
@@ -172,7 +172,7 @@ public class ThirdPersonUserControl : MonoBehaviour
 
         // Don't take inputs for character movement unless we're in the right state.
         StateManager.State state = stateManager.GetState();
-        if (state != StateManager.State.Normal && state != StateManager.State.Looking)
+        if (state != StateManager.State.Normal && state != StateManager.State.Looking || isPaused)
             return;
 
 

--- a/Assets/Scripts/Gravity/GravityManager.cs
+++ b/Assets/Scripts/Gravity/GravityManager.cs
@@ -119,7 +119,7 @@ public class GravityManager : MonoBehaviour
         }
 
         /* Handle looking up. (Y button or L key) */
-        if (state == StateManager.State.Normal && readyToFlip && Input.GetButtonDown("LookUp") && !playerChar.isGrabbingSomething)
+        if (state == StateManager.State.Normal && readyToFlip && Input.GetButtonDown("LookUp") && !playerChar.isGrabbingSomething && !stateManager.IsPaused())
         {
             looking = true;
             lookUpFadeAnimator.ResetTrigger("StopLooking");


### PR DESCRIPTION
When in doubt, add one more flag!
By breaking early if "isPaused" flag is set during input collection, this ensures bot capture and char switch during pause won't happen