### PR TITLE
keep ending music playing into credits

### DIFF
--- a/Assets/Scenes/Credits.unity
+++ b/Assets/Scenes/Credits.unity
@@ -1244,7 +1244,7 @@ AudioSource:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1722541580}
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 99da9c4f3816da74e9e1733b0acd9da9, type: 3}

--- a/Assets/Scenes/Ending.unity
+++ b/Assets/Scenes/Ending.unity
@@ -807,6 +807,146 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1580031971
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1580031974}
+  - component: {fileID: 1580031973}
+  - component: {fileID: 1580031972}
+  m_Layer: 0
+  m_Name: EndingMusic
+  m_TagString: EndingMusic
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1580031972
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580031971}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db4bd58d5e121854784e56abd063a2c9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!82 &1580031973
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580031971}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 8300000, guid: abbae35537f374d4d8880fb1edc469eb, type: 3}
+  m_PlayOnAwake: 1
+  m_Volume: 0.6
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!4 &1580031974
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580031971}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 484.00003, y: 273.50003, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1722541580
 GameObject:
   m_ObjectHideFlags: 0
@@ -865,7 +1005,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: abbae35537f374d4d8880fb1edc469eb, type: 3}
-  m_PlayOnAwake: 1
+  m_PlayOnAwake: 0
   m_Volume: 0.6
   m_Pitch: 1
   Loop: 1

--- a/Assets/Scripts/Ending/CreditsScript.cs
+++ b/Assets/Scripts/Ending/CreditsScript.cs
@@ -73,6 +73,7 @@ public class CreditsScript : MonoBehaviour
         }
 
         creditsOver = true;
+        sceneLoader.fadeAudioInOut = true;
     }
 
     void InitializeCreditsText()

--- a/Assets/Scripts/Ending/EndingMusic.cs
+++ b/Assets/Scripts/Ending/EndingMusic.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EndingMusic : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        DontDestroyOnLoad(this.gameObject);
+    }
+
+    public void destroythis()
+    {
+        Destroy(this.gameObject);
+    }
+
+}

--- a/Assets/Scripts/Ending/EndingMusic.cs.meta
+++ b/Assets/Scripts/Ending/EndingMusic.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db4bd58d5e121854784e56abd063a2c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ending/EndingScript.cs
+++ b/Assets/Scripts/Ending/EndingScript.cs
@@ -53,7 +53,7 @@ public class EndingScript : MonoBehaviour
 
             yield return new WaitForSecondsRealtime(waitBetweenTextTime);
         }
-
+        sceneLoader.fadeAudioInOut = false;
         sceneLoader.LoadNextScene();
     }
 

--- a/Assets/Scripts/UI/MainMenuManager.cs
+++ b/Assets/Scripts/UI/MainMenuManager.cs
@@ -43,6 +43,9 @@ public class MainMenuManager : MonoBehaviour
     {
         Cursor.visible = false;
 
+        // if we are starting the game from the end, clean up our ending music!
+        GameObject.FindGameObjectWithTag("EndingMusic")?.GetComponent<EndingMusic>().destroythis();
+
         // Set up for intro animations
         titleText.maxVisibleCharacters = 0;
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -19,6 +19,7 @@ TagManager:
   - DialogText
   - KiraWatch
   - FloppyProps
+  - EndingMusic
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
This keeps the ending music playing over the credits.
Maintains a don'tdestoryonload object which plays the music between scene cuts and is destroyed when the main menu is activated, so all fades play nice and smoothly