### PR TITLE
Check for robot in way of pushing crate

### DIFF
--- a/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
+++ b/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
@@ -547,7 +547,7 @@ public class ThirdPersonUserControl : MonoBehaviour
                 {
                     foreach (Collider c in hitColliders)
                     {
-                        if (c.gameObject.CompareTag("Player") || c.gameObject.CompareTag("robot") || c.gameObject == this.gameObject || c.gameObject.CompareTag("FloppyProps"))
+                        if (c.gameObject.CompareTag("Player") || (pullBackwards && c.gameObject.CompareTag("robot")) || c.gameObject == this.gameObject || c.gameObject.CompareTag("FloppyProps"))
                         {
                             // Ignore player, robot, and ourselves
                             continue;


### PR DESCRIPTION
This will not allow the player to push the crate into the robot which should solve some crate alignment issues