### PR TITLE
Cam smoothing

### DIFF
--- a/Assets/Scripts/Camera/CameraControl.cs
+++ b/Assets/Scripts/Camera/CameraControl.cs
@@ -56,11 +56,16 @@ public class CameraControl : MonoBehaviour
     {
         if (gravityManager.isFlipping && !changingTarget && !screenShaking)
         {
-            transform.position = target.position + offset;
-            transform.LookAt(target.position);
-
+            SetDefaultPositionRotation();
             audioListenerObject.position = transform.position - offset;
         }
+    }
+
+    // Used to reset the camera on lateupdate, also called on look up/down.
+    public void SetDefaultPositionRotation()
+    {
+        transform.position = target.position + offset;
+        transform.LookAt(target.position);
     }
 
     void FixedUpdate()
@@ -210,11 +215,9 @@ public class CameraControl : MonoBehaviour
             yield return null;
         }
 
-        transform.LookAt(newTarget.position);
-
         if (lookAtTarget)
         {
-            transform.LookAt(target.position);
+            transform.LookAt(newTarget.position);
             transform.position = newTarget.position + offset;
         }
         else
@@ -222,7 +225,6 @@ public class CameraControl : MonoBehaviour
             transform.rotation = newTarget.rotation;
             transform.position = newTarget.position;
         }
-
 
         target = newTarget;
         changingTarget = false;

--- a/Assets/Scripts/Camera/CameraControl.cs
+++ b/Assets/Scripts/Camera/CameraControl.cs
@@ -36,6 +36,12 @@ public class CameraControl : MonoBehaviour
         if (!target) target = GameObject.FindWithTag("Player").transform;
     }
 
+    // Don't be lerping in the first few frames!
+    void Start()
+    {
+        SetDefaultPositionRotation();
+    }
+
     // USE THE BELOW TO TEST SCREEN SHAKE
     // void Update()
     // {

--- a/Assets/Scripts/Gravity/GravityManager.cs
+++ b/Assets/Scripts/Gravity/GravityManager.cs
@@ -262,6 +262,9 @@ public class GravityManager : MonoBehaviour
         player.transform.localRotation = playerEndRot;
         player.GetComponent<Rigidbody>().isKinematic = false;
         player.GetComponent<CapsuleCollider>().enabled = true;
+
+        // Reset camera position (skip the lerps)
+        CameraControl.CC.SetDefaultPositionRotation();
     }
 
     void FlipGravity()


### PR DESCRIPTION
It may not seem like much, but funnily enough a lot of work went into this simple demonstration:

Try smashing opposite directions back 'n forth on main branch (on joystick). See how jumpy the whole world gets?
Now do it on this branch... less jumpy! Whoo!

We can change how gentle/slow the camera lerping is by modifying `lerpModifier` at line 24, but too low a value is too slow and too high will probably be jerky again, so `25f` seems solid.

Tested with the "cinematic" camera scenes as well, should not affect them