### PR TITLE
Disallow character switching during pushing/grabbing

### DIFF
--- a/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
+++ b/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
@@ -152,6 +152,19 @@ public class ThirdPersonUserControl : MonoBehaviour
             ResetScene();
         }
 
+        // make sure we always check if we're holding the use button or not
+        // since other scripts may depend on this happening?
+        if (Input.GetButtonDown("Interact"))
+        {
+            // Player has starte holding down the grab button
+            HoldingUseButton = true;
+        }
+        if (Input.GetButtonUp("Interact"))
+        {
+            // Player lets go of the grab button
+            HoldingUseButton = false;
+        }
+
         // always check for pause menu, no matter the state
         if (Input.GetButtonDown("Start") || Input.GetKeyDown(KeyCode.Escape))
         {
@@ -180,18 +193,7 @@ public class ThirdPersonUserControl : MonoBehaviour
 
 
 
-        // make sure we always check if we're holding the use button or not
-        // since other scripts may depend on this happening?
-        if (Input.GetButtonDown("Interact"))
-        {
-            // Player has starte holding down the grab button
-            HoldingUseButton = true;
-        }
-        if (Input.GetButtonUp("Interact"))
-        {
-            // Player lets go of the grab button
-            HoldingUseButton = false;
-        }
+
 
         // if we're in a pushing animation, don't deal with input for now
         if (isInMovingAnimation)

--- a/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
+++ b/Assets/Characters/ThirdPersonCharacter/Scripts/ThirdPersonUserControl.cs
@@ -65,6 +65,7 @@ public class ThirdPersonUserControl : MonoBehaviour
     bool pullBackwards;                     // players current status is pulling a crate towards themselves
 
     bool dropCrateWhenAnimationDone;
+    public bool isGrabbing;
 
     bool isPaused;
 
@@ -73,6 +74,7 @@ public class ThirdPersonUserControl : MonoBehaviour
 
     private void Start()
     {
+
         stateManager = GameObject.FindObjectOfType<StateManager>();
         sl = GameObject.Find("SceneLoader").GetComponent<SceneLoader>();
 
@@ -105,6 +107,7 @@ public class ThirdPersonUserControl : MonoBehaviour
         isInMovingAnimation = false;
         movingAnimationCount = 0.0f;
         dropCrateWhenAnimationDone = false;
+        isGrabbing = false;
 
         m_LayerMask = ~(1 << 17 | 1 << 11 | 1 << 12);    // don't collide with occlusion volumes, triggers, or NoFlip Zones
     }
@@ -269,7 +272,7 @@ public class ThirdPersonUserControl : MonoBehaviour
                 r_Character.unbreakranks(); // make it follow the player again
             }
 
-            if (canSelectBot && Input.GetButtonDown("SwitchChar"))
+            if (!isGrabbing && canSelectBot && Input.GetButtonDown("SwitchChar"))
             {
                 SwitchChar();
             }

--- a/Assets/Scripts/BoxPush.cs
+++ b/Assets/Scripts/BoxPush.cs
@@ -227,6 +227,7 @@ public class BoxPush : MonoBehaviour
             m_Character.StopMoving();   // take away player momentum
             m_Character.grabbedBox = this.gameObject;
         }
+        playerControls.isGrabbing = playerGrabbing || playerIsPushing;
     }
 
     void OnDrawGizmosSelected()

--- a/Assets/Scripts/BoxPush.cs
+++ b/Assets/Scripts/BoxPush.cs
@@ -81,7 +81,7 @@ public class BoxPush : MonoBehaviour
     void HandleSwitchChar(object sender, ThirdPersonUserControl.SwitchCharArgs args)
     {
         GameObject selected = args.selected;
-
+        DropCrate();
         if (selected.tag == "Player" && canPushCrate)
         {
             ShowPrompt();
@@ -92,6 +92,23 @@ public class BoxPush : MonoBehaviour
     {
         uiManager.EnterRange(playerObject.tag, "(Hold)");
         showingPrompt = true;
+    }
+
+    void DropCrate()
+    {
+        // Here, we are letting go of grabbing a box
+        // reset timer and flags
+        snapOnce = true;
+        m_Character.isGrabbingSomething = false;
+        m_Character.disallowRotation = false;
+        m_Character.StopPushPullAnim();
+        m_Character.grabbedBox = null;
+        m_Character.lockOnZAxis = false;
+        m_Character.lockOnXAxis = false;
+        secondsOfPushing = 0.0f;
+        playerIsPushing = false;
+        playerGrabbing = false;
+        boxRigidbody.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionX | RigidbodyConstraints.FreezePositionZ;
     }
 
     void HidePrompt()
@@ -136,7 +153,7 @@ public class BoxPush : MonoBehaviour
         }
 
         // we can push the crate and we're holding the use button AND the player is selected
-        if (canPushCrate && playerHoldingUse && stateManager.GetSelected().tag == "Player")
+        if (!playerIsPushing && canPushCrate && playerHoldingUse && stateManager.GetSelected().tag == "Player")
         {
             if (!playerGrabbing)
             {
@@ -156,7 +173,6 @@ public class BoxPush : MonoBehaviour
                 secondsOfPushing += Time.deltaTime;
             }
         }
-
         // we are in pushing state, but still counting towards pushing
         if (!playerIsPushing && (secondsOfPushing > pushThreshold))
         {
@@ -166,23 +182,30 @@ public class BoxPush : MonoBehaviour
 
         if ((playerIsPushing || playerGrabbing) && !playerHoldingUse)
         {
-            // Here, we are letting go of grabbing a box
-            // reset timer and flags
-            snapOnce = true;
-            m_Character.isGrabbingSomething = false;
-            m_Character.disallowRotation = false;
-            m_Character.StopPushPullAnim();
-            m_Character.grabbedBox = null;
-            m_Character.lockOnZAxis = false;
-            m_Character.lockOnXAxis = false;
-            secondsOfPushing = 0.0f;
-            playerIsPushing = false;
-            playerGrabbing = false;
-            boxRigidbody.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionX | RigidbodyConstraints.FreezePositionZ;
+            DropCrate();
+            //// Here, we are letting go of grabbing a box
+            //// reset timer and flags
+            //snapOnce = true;
+            //m_Character.isGrabbingSomething = false;
+            //m_Character.disallowRotation = false;
+            //m_Character.StopPushPullAnim();
+            //m_Character.grabbedBox = null;
+            //m_Character.lockOnZAxis = false;
+            //m_Character.lockOnXAxis = false;
+            //secondsOfPushing = 0.0f;
+            //playerIsPushing = false;
+            //playerGrabbing = false;
+            //boxRigidbody.constraints = RigidbodyConstraints.FreezeRotation | RigidbodyConstraints.FreezePositionX | RigidbodyConstraints.FreezePositionZ;
         }
 
         if (playerIsPushing)
         {
+            if (!playerHoldingUse)
+            {
+                DropCrate();
+                playerControls.isGrabbing = playerGrabbing || playerIsPushing;
+                return;
+            }
             // here, we've just started pushing
             // let the character know we're grabbing something 
             player.GetComponent<ThirdPersonCharacter>().isGrabbingSomething = true;


### PR DESCRIPTION
disallow player to switch to robot while grabbing and/or pushing a crate around