### PR TITLE
Fix up lift audio to kill overlap that gets too loud

### DIFF
--- a/Assets/Resources/LiftAudio.prefab
+++ b/Assets/Resources/LiftAudio.prefab
@@ -1,0 +1,142 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1086810529456438223
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4657030184301453511}
+  - component: {fileID: 2013487670145592237}
+  - component: {fileID: 8484505331083341854}
+  m_Layer: 0
+  m_Name: LiftAudio
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4657030184301453511
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086810529456438223}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 124.847466, y: 2.5199955, z: 42.463696}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2013487670145592237
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086810529456438223}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9881e16c99d1402448f1d644689462cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!82 &8484505331083341854
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086810529456438223}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 8300000, guid: ff9748838dca93e40b5e6ab30fc7b9f0, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 0.5
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Resources/LiftAudio.prefab.meta
+++ b/Assets/Resources/LiftAudio.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aee3931b409d1444e8ce3f9f3406d914
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LiftAction.cs
+++ b/Assets/Scripts/LiftAction.cs
@@ -17,6 +17,10 @@ public class LiftAction : MonoBehaviour, IObjectAction
     void Start()
     {
         stateManager = FindObjectOfType<StateManager>();
+        if (FindObjectOfType<LiftAudio>() == null)
+        {
+            GameObject.Instantiate(Resources.Load("LiftAudio"), Vector3.zero, Quaternion.identity);
+        }
         // originalPosition = transform.position;
 
     }
@@ -25,7 +29,7 @@ public class LiftAction : MonoBehaviour, IObjectAction
     {
         if (allowUse)
         {
-            GetComponent<AudioSource>()?.Play();
+            FindObjectOfType<LiftAudio>().PlaySound();
 
             if (lifted)
             {

--- a/Assets/Scripts/LiftAudio.cs
+++ b/Assets/Scripts/LiftAudio.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+public class LiftAudio : MonoBehaviour
+{
+    AudioSource audioSource;
+
+    void Start()
+    {
+        audioSource = GetComponent<AudioSource>();
+    }
+
+    public void PlaySound()
+    {
+        audioSource.Play();
+    }
+}

--- a/Assets/Scripts/LiftAudio.cs.meta
+++ b/Assets/Scripts/LiftAudio.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9881e16c99d1402448f1d644689462cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Script change only.

LiftAction.cs now instantiates a new gameobject with an audiosource, if it doesn't already exist. All lifts then look for this single audiosource to play their sound, so none can overlap and get too loud. Most noticeable on 3-2 where you ears no longer blow out every time you press the red switch on the top right puzzle